### PR TITLE
perf: replace mongosh ping with Python script for lightweight healthcheck

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -3,12 +3,15 @@ name: stoat
 services:
   # MongoDB: Database
   database:
-    image: docker.io/mongo
+    build: 
+      context: . 
+      dockerfile: mongo.Dockerfile
     restart: always
     volumes:
       - ./data/db:/data/db
+      - ./mongo_ping.py:/mongo_ping.py
     healthcheck:
-      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet
+      test: ["CMD", "python3", "/mongo_ping.py"]
       interval: 10s
       timeout: 10s
       retries: 5

--- a/mongo.Dockerfile
+++ b/mongo.Dockerfile
@@ -1,0 +1,6 @@
+FROM docker.io/mongo:latest
+
+# install Python3, pip, pymongo for low memory usage healthcheck
+RUN apt-get update && \
+    apt-get install -y python3 python3-pip python3-pymongo && \
+    rm -rf /var/lib/apt/lists/*

--- a/mongo_ping.py
+++ b/mongo_ping.py
@@ -1,0 +1,24 @@
+from pymongo import MongoClient
+from pymongo.errors import PyMongoError
+import sys
+import json
+
+try:
+    client = MongoClient(
+        "mongodb://localhost:27017",
+        connectTimeoutMS=3000,
+        serverSelectionTimeoutMS=5000,
+        socketTimeoutMS=5000,
+        directConnection=True,
+    )
+
+    client.admin.command("ping")
+    print(json.dumps({"ok": 1}))
+    sys.exit(0)
+
+except PyMongoError as e:
+    print(json.dumps({
+        "ok": 0,
+        "error": str(e)
+    }, ensure_ascii=False), file=sys.stderr)
+    sys.exit(1)


### PR DESCRIPTION
Replace mongosh ping with Python script for lightweight healthcheck.
Makes it more friendly for servers with limited memory and CPU performance.

> Testing with my 2C2G cloud server.
All other stoat containers are paused. 
Due to inconsistent monitoring refresh intervals, test results may be inaccurate.

Test setting:
<img width="701" height="115" alt="test_setting" src="https://github.com/user-attachments/assets/8af12b64-e604-45be-9601-b3f013e09361" />

Before modification:
CPU could reach as high as 50%, memory could reach as high as 400+MB.
<img width="1200" height="644" alt="before_healthcheck" src="https://github.com/user-attachments/assets/6511c5fe-2fc9-4bdb-b183-0a2786547a8c" />

After modification:
CPU usage peaked at 10%, memory usage remained around 270MB.
<img width="1200" height="650" alt="modified _healthcheck" src="https://github.com/user-attachments/assets/d41cbb98-8527-4640-a8fd-a63372ab172b" />

Without healthcheck:
<img width="1200" height="650" alt="unable_healthcheck" src="https://github.com/user-attachments/assets/48665469-8277-44ef-8e44-31f829140318" />
