### PR TITLE
feat: Add VITE_HOST env var for instance PR

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -222,7 +222,7 @@ services:
 
   # Web App
   web:
-    # for-web v0.10.0
-    image: ghcr.io/stoatchat/for-web:746bee5
+    # for-web v0.14.1
+    image: ghcr.io/stoatchat/for-web:2a74823
     restart: always
     env_file: .env.web

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -179,13 +179,8 @@ fi
 
 # set hostname for Caddy and vite variables
 echo "HOSTNAME=$STOAT_HOSTNAME" > .env.web
-echo "REVOLT_PUBLIC_URL=https://$DOMAIN/api" >> .env.web
+echo "VITE_HOST=$DOMAIN" >> .env.web
 echo "VITE_API_URL=https://$DOMAIN/api" >> .env.web
-echo "VITE_WS_URL=wss://$DOMAIN/ws" >> .env.web
-echo "VITE_MEDIA_URL=https://$DOMAIN/autumn" >> .env.web
-echo "VITE_PROXY_URL=https://$DOMAIN/january" >> .env.web
-echo "VITE_GIFBOX_URL=https://$DOMAIN/gifbox" >> .env.web
-echo "VITE_CFG_ENABLE_VIDEO=$VIDEO_ENABLED" >> .env.web
 
 # client config
 echo -n "{\"api\":\"https://$DOMAIN/api\"}" > stoat.json


### PR DESCRIPTION
Required change for when https://github.com/stoatchat/for-web/pull/1315 is merged.

New VITE_HOST environment var for web takes the place of all the other individual configuration URLs (VITE_WS_URL, VITE_MEDIA_URL, etc.) that will now be pulled from the backend. Well, technically the existing VITE_API_URL var takes the place of them, the VITE_HOST is necessary because the API could exist at a nonstandard path relative to the frontend domain, though it is almost always `https://domain.com/api`, we don't want to assume this with no way to override it.